### PR TITLE
Fixed file count method

### DIFF
--- a/craftersmine.Asar.Net/AsarArchiveFile.cs
+++ b/craftersmine.Asar.Net/AsarArchiveFile.cs
@@ -102,6 +102,8 @@ namespace craftersmine.Asar.Net
                 {
                     fileCount += f.GetFileCount();
                 }
+
+                fileCount++;
             }
             else
                 fileCount++;


### PR DESCRIPTION
Fixed `AsarArchiveFile.GetFileCount()` method which returned invalid count of files and directories in selected file/directory